### PR TITLE
Code Smell 일부 제거

### DIFF
--- a/coupon-consumer/src/main/java/com/example/couponconsumer/configuration/KafkaConsumerConfiguration.java
+++ b/coupon-consumer/src/main/java/com/example/couponconsumer/configuration/KafkaConsumerConfiguration.java
@@ -17,25 +17,25 @@ import java.util.Map;
 @Configuration
 public class KafkaConsumerConfiguration {
     @Value("${spring.kafka.bootstrap-servers}")
-    private String BOOTSTRAP_SERVERS;
+    private String bootstrapServers;
 
     @Value("${spring.kafka.consumer.auto-offset-reset}")
-    private String AUTO_OFFSET_RESET; // earliest: 토픽의 가장 처음 부터 읽음
+    private String autoOffsetReset; // earliest: 토픽의 가장 처음 부터 읽음
 
     @Value("${spring.kafka.consumer.enable-auto-commit}")
-    private boolean ENABLE_AUTO_COMMIT;
+    private boolean enableAutoCommit;
 
     @Value("${spring.kafka.consumer.key-deserializer}")
-    private String KEY_DESERIALIZER;
+    private String keyDeserializer;
 
     @Value("${spring.kafka.consumer.value-deserializer}")
-    private String VALUE_DESERIALIZER;
+    private String valueDeserializer;
 
     @Value("${spring.kafka.consumer.group-id}")
-    private String GROUP_ID; //필수
+    private String groupId; //필수
 
     @Value("${spring.kafka.properties.spring.json.trusted.packages}")
-    private String TRUSTED_PACKAGES;
+    private String trustedPackages;
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<Long, CouponIssueKafkaEvent> kafkaListenerContainerFactory() {
@@ -48,13 +48,13 @@ public class KafkaConsumerConfiguration {
     @Bean
     public ConsumerFactory<Long, CouponIssueKafkaEvent> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AUTO_OFFSET_RESET);
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, ENABLE_AUTO_COMMIT);
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KEY_DESERIALIZER);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, VALUE_DESERIALIZER);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, TRUSTED_PACKAGES);
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, trustedPackages);
 
         return new DefaultKafkaConsumerFactory<>(props,
                 new LongDeserializer(),

--- a/coupon-core/src/main/java/com/example/couponcore/util/CouponRedisUtils.java
+++ b/coupon-core/src/main/java/com/example/couponcore/util/CouponRedisUtils.java
@@ -2,14 +2,17 @@ package com.example.couponcore.util;
 
 public class CouponRedisUtils {
 
+    private static final String ISSUE_REQUEST_KEY_FORMAT = "issue.request.couponId=%s";
+    private static final String ISSUE_REQUEST_QUEUE_KEY = "issue.request";
+
     private CouponRedisUtils() {
     }
 
     public static String getIssueRequestKey(long couponId) {
-        return "issue.request.couponId=%s".formatted(couponId);
+        return ISSUE_REQUEST_KEY_FORMAT.formatted(couponId);
     }
 
     public static String getIssueRequestQueueKey() {
-        return "issue.request";
+        return ISSUE_REQUEST_QUEUE_KEY;
     }
 }

--- a/coupon-core/src/test/java/com/example/couponcore/service/AsyncCouponIssueServiceTest.java
+++ b/coupon-core/src/test/java/com/example/couponcore/service/AsyncCouponIssueServiceTest.java
@@ -82,8 +82,9 @@ class AsyncCouponIssueServiceTest extends TestConfig {
                 .build();
         couponJpaRepository.save(coupon);
 
+        Long couponId = coupon.getId();
         CouponIssueException couponIssueException = catchThrowableOfType(() -> {
-            asyncCouponIssueService.issue(coupon.getId(), 1L);
+            asyncCouponIssueService.issue(couponId, 1L);
         }, CouponIssueException.class);
 
         assertThat(couponIssueException.getErrorCode())
@@ -104,11 +105,13 @@ class AsyncCouponIssueServiceTest extends TestConfig {
                 .build();
         couponJpaRepository.save(coupon);
 
+        Long couponId = coupon.getId();
+
         IntStream.range(0, coupon.getTotalQuantity())
-                .forEach(userId -> redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(userId)));
+                .forEach(userId -> redisTemplate.opsForSet().add(getIssueRequestKey(couponId), String.valueOf(userId)));
 
         CouponIssueException couponIssueException = catchThrowableOfType(() -> {
-            asyncCouponIssueService.issue(coupon.getId(), 999L);
+            asyncCouponIssueService.issue(couponId, 999L);
         }, CouponIssueException.class);
 
         assertThat(couponIssueException.getErrorCode())
@@ -132,8 +135,9 @@ class AsyncCouponIssueServiceTest extends TestConfig {
         long userId = 1L;
         redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(userId));
 
+        Long couponId = coupon.getId();
         CouponIssueException couponIssueException = catchThrowableOfType(() -> {
-            asyncCouponIssueService.issue(coupon.getId(), userId);
+            asyncCouponIssueService.issue(couponId, userId);
         }, CouponIssueException.class);
 
         assertThat(couponIssueException.getErrorCode())


### PR DESCRIPTION
1. 불필요한 주석 제거
2. 변수명 renaming (snake_case 명명하거나 예약어 사용하는 경우)

3. `Refactor the code of the lambda to have only one invocation possibly throwing a runtime exception.`
- 원인: 람다식에서 예외를 던질만한 메소드 호출이 하나여야 하는데 getter가 있어 소나 규칙에 걸림 
- 해결: `couponId` 변수 추출하여 해결 

💩before
```java
CouponIssueException couponIssueException = catchThrowableOfType(() -> {
            asyncCouponIssueService.issue(coupon.getId(), 1L);
        }, CouponIssueException.class);
```

✨after
```java
Long couponId = coupon.getId();
CouponIssueException couponIssueException = catchThrowableOfType(() -> {
            asyncCouponIssueService.issue(couponId, 1L);
        }, CouponIssueException.class);
```


4. `Call transactional methods via an injected dependency instead of directly via 'this'.` 
- this 사용하여 호출할 경우 프록시 기능을 사용하지 못하는 한계에 대한 내용
- self inject 방식을 써서 자기 자신을 빈으로 주입받아 호출하거나, 서비스 빈을 분리해서 호출하는 방식으로 처리 가능
- 하지만 리팩터링할 경우 코드 복잡도만 높아지고 현재 트랜잭션을 세밀하게 제어할 필요까지는 없다 판단하여 그대로 남김

```java
@Service
public class CouponIssueService {
     //..

     @Transactional
      public void issueWithLock(long couponId, long userId) {
          Coupon coupon = findCouponWithLock(couponId); // 🙌
          coupon.issue();
          saveCouponIssue(couponId, userId); // 🙌
          publishCouponEvent(coupon);
      }
}
```